### PR TITLE
Tweak: PowerToys

### DIFF
--- a/Documentation/changelog.md
+++ b/Documentation/changelog.md
@@ -1,5 +1,11 @@
 # Changelog.md - pcHealth
 
+## 30-04-2024 - @REALSDEALS
+
+Fixed a beginner mistake, running a PowerShell command in CMD. 
+    --> PowerToys command will now run the command as a PowerShell command; installation follows through and works as intended.
+        --> Sidenote... maybe include a 'winget' install tool too, since if breaks when the user doesn't have this installed.
+
 ## 26-04-2024 - @REALSDEALS
 
 Under the tools section there has been added a new addition; the installation of Windows PowerToys.

--- a/Documentation/releases.md
+++ b/Documentation/releases.md
@@ -6,7 +6,7 @@ For now only the version names will be displayed, in the future there might be e
 # Current Version(s)
 
 Full Release - v1.7.0 (Stable)
-Beta Release - v1.8.0-beta
+Beta Release - v1.8.1-beta
 =======
 Alpha Release - v0.3.0-alpha (PowerShell) ((DISCONTINUED))
 
@@ -35,6 +35,7 @@ Here you can see a overview of the older version.
 
 ### Beta Release(s)
 
+- Beta Release - v1.8.1-beta
 - Beta Release - v1.8.0-beta
 - Beta Release - v1.7.2-beta
 - Beta Release - v1.7.1-beta

--- a/Scripts/CMD/pcHealth.bat
+++ b/Scripts/CMD/pcHealth.bat
@@ -29,7 +29,7 @@ if '%errorlevel%' NEQ '0' (
 :--------------------------------------    
 :: MainCode
 @echo off
-title pcHealth - Check your PC's Health! - version 1.8.0-beta
+title pcHealth - Check your PC's Health! - version 1.8.1-beta
 =======
 cd /
 color D
@@ -43,7 +43,7 @@ echo Thanks for downloading and using pcHealth!
 echo Please be sure that you are running this Batch file in Administrator mode.
 echo.
 echo Made by REALSDEALS - Licensed under GNU-3 (You are free to use, but not to change or to remove this line.)
-echo You are now using version 1.8.0-beta of pcHealth.
+echo You are now using version 1.8.1-beta of pcHealth.
 =======
 echo.
 echo %DATE%, %TIME%
@@ -656,12 +656,13 @@ IF %AQ%==2 GOTO TOOLS
 cls
 color 0A
 echo.
-echo Your installation of Windows PowerToys will start; keep in mind that it could open a new CMD prompt.
+echo Your installation of Windows PowerToys will start; keep in mind that it could open a new CMD prompt or PowerShell prompt.
 echo. 
-winget install Microsoft.PowerToys --source winget
+powershell -command "winget install Microsoft.PowerToys --source winget"
 echo.
 echo After the installation, this prompt will close on a keypress. 
 pause
+GOTO CLOSEACT
 
 :PRERELEASE
 cls
@@ -696,6 +697,17 @@ echo.
 SET /P AP=To return to the main menu enter 1 or to close the script enter 2. Enter: 
 IF %AP%==1 GOTO MENU
 IF %AP%==2 GOTO CLOSE
+
+:CLOSEACT
+cls
+color 0A
+echo.
+echo Your requested software has been installed, what would you like to do next?
+echo.
+SET /P Do you wish to return to the main menu? Enter number 1. If you wish to return to the previous sub menu; enter number 2. If you wish to close this script; enter number 3. Enter: 
+IF %AS%==1 GOTO MENU
+IF %AS%==2 GOTO TOOLS
+IF %AS%==3 GOTO CLOSE
 
 :CLOSE
 EXIT /B


### PR DESCRIPTION
Tweak: Made a tweak in the new added function; PowerToys. When the user tried to install this feature through the script, it would break. Since the script was trying to run a PowerShell command in CMD.

This issue has been resolved. The script now emulates the command in CMD as a PowerShell command. Sounds complicated but this is a standard issue which I should have implemented from the start. But lets say I made a minor error by rushing it.

Only possible error that might occur is that it could give a 'winget' error. It occured to me on one of my test VM's. From the 3, 1 had a failure.