### PR TITLE
Add: Preparation of Bootrec Script

### DIFF
--- a/Documentation/releases.md
+++ b/Documentation/releases.md
@@ -6,7 +6,7 @@ For now only the version names will be displayed, in the future there might be e
 # Current Version(s)
 
 Full Release - v1.8.3 (Stable)  
-Beta Release - v1.9.0-beta
+Beta Release - v1.9.1-beta
 =======
 Alpha Release - v0.3.0-alpha (PowerShell) ((DISCONTINUED))
 
@@ -37,6 +37,7 @@ Here you can see a overview of the older version.
 
 ### Beta Release(s)
 
+- Beta Release - v1.9.1-beta
 - Beta Release - v1.9.0-beta
 - Beta Release - v1.8.5-beta
 - Beta Release - v1.8.4-beta

--- a/Scripts/CMD/pcHealth.bat
+++ b/Scripts/CMD/pcHealth.bat
@@ -29,7 +29,7 @@ if '%errorlevel%' NEQ '0' (
 :--------------------------------------    
 :: MainCode
 @echo off
-title pcHealth - Check your PC's Health! - version 1.9.0-beta
+title pcHealth - Check your PC's Health! - version 1.9.1-beta
 =======
 cd /
 color D
@@ -43,7 +43,7 @@ echo Thanks for downloading and using pcHealth!
 echo Please be sure that you are running this Batch file in Administrator mode.
 echo.
 echo Made by REALSDEALS - Licensed under GNU-3 (You are free to use, but not to change or to remove this line.)
-echo You are now using version 1.9.0-beta of pcHealth.
+echo You are now using version 1.9.1-beta of pcHealth.
 =======
 echo.
 for /f "skip=2 tokens=1,2,*" %%a in ('reg query "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Authentication\LogonUI" /v LastLoggedOnDisplayName 2^>nul') do set FullName=%%c
@@ -97,10 +97,11 @@ echo Enter number 18 to re-open the CBS.log (AKA DISM.log)
 echo Enter number 19 to get your Ninite! Includes Edge, Chrome, VLC and 7Zip.
 echo Enter number 20 to see your systems Windows License key.
 echo Enter number 21 BIOS Password Recovery.
-echo Enter number 22 to shutdown, reboot or log off from your PC/laptop.
-echo Enter number 23 to open the programs menu.
-echo Enter number 24 to return to the previous menu.
-echo Enter number 25 to close this batch file.
+echo Enter number 22 to try and repair the boot record of your system. (Use with caution and only if you know what you are doing! ((From a Blue Screen + CMD,) might render your system unbootable!))
+echo Enter number 23 to shutdown, reboot or log off from your PC/laptop.
+echo Enter number 24 to open the programs menu.
+echo Enter number 25 to return to the previous menu.
+echo Enter number 26 to close this batch file.
 echo ...........................................................
 echo.
 
@@ -126,10 +127,11 @@ IF %B%==18 GOTO OPENCBSLOG
 IF %B%==19 GOTO NINITE
 IF %B%==20 GOTO LICENSE
 IF %B%==21 GOTO BIOSPW
-IF %B%==22 GOTO RESHUT
-IF %B%==23 GOTO PROGRAMS
-IF %B%==24 GOTO MENU
-IF %B%==25 GOTO CLOSE
+IF %B%==22 GOTO BOOTRESTORE
+IF %B%==23 GOTO RESHUT
+IF %B%==24 GOTO PROGRAMS
+IF %B%==25 GOTO MENU
+IF %B%==26 GOTO CLOSE
 
 :PROGRAMS
 cls
@@ -519,6 +521,44 @@ IF %SK%==2 start "" https://github.com/bacher09/pwgen-for-bios && GOTO BIOSPW
 IF %SK%==3 GOTO TOOLS
 IF %SK%==4 GOTO MENU
 IF %SK%==5 GOTO CLOSE 
+
+:BOOTRESTORE
+cls
+color 0A
+echo.
+echo This function will try and repair the boot record of your system.
+echo.
+echo Please be aware that this function should only be used if you know what you are doing!
+echo.
+echo Using this function from a Blue Screen + CMD might render your system unbootable!
+echo.
+SET /P SL=If you want to continue and if you are sure what you are doing, enter number 1. To return to the previous sub-menu, enter number 2. To return to the main-menu, enter number 3 or to exit the script, enter number 4. Enter: 
+IF %SL%==1 GOTO BOOTRESTORECONFIRM
+IF %SL%==2 GOTO TOOLS
+IF %SL%==3 GOTO MENU
+IF %SL%==4 GOTO CLOSE
+
+:BOOTRESTORECONFIRM
+cls
+color 0C
+echo.
+echo Are you really sure that you want to continue? This might render your system unbootable!
+echo.
+SET /P SM=If you are sure, enter number 1. To return to the previous sub-menu, enter number 2. To return to the main-menu, enter number 3 or to exit the script, enter number 4. Enter: 
+IF %SM%==1 GOTO BOOTRESTORESTART
+IF %SM%==2 GOTO TOOLS
+IF %SM%==3 GOTO MENU
+IF %SM%==4 GOTO CLOSE
+
+:BOOTRESTORESTART
+cls
+color 0C
+echo.
+echo Starting the boot record repair...
+echo.
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0..\PS1\Repair_BootRecord.ps1"
+echo.
+pause
 
 :RESHUT
 cls

--- a/Scripts/PS1/Repair_BootRecord.ps1
+++ b/Scripts/PS1/Repair_BootRecord.ps1
@@ -1,0 +1,73 @@
+Write-Host "Boot Record Repair Script"
+Write-Host "As part of the pcHealth script: check GitHub for more info; github.com/realsdeals/pcHealth"
+Write-Host "-------------------------"
+# -------------------------------
+Write-Host "Starting Boot Record Repair..."
+
+function Get-WindowsDrive {
+    $candidates = Get-PSDrive -PSProvider FileSystem | Where-Object { $_.Name -ne 'X' }
+    foreach ($d in $candidates) {
+        if (Test-Path (Join-Path "$($d.Root)" "Windows\System32")) {
+            return ($d.Name + ":")
+        }
+    }
+    return $null
+}
+
+function Run_Chkdsk {
+    Write-Host "`n[CHKDSK] Scanning disk with /f /r..." -ForegroundColor Cyan
+    $win = Get-WindowsDrive
+    if (-not $win) { Write-Warning "No Windows partition found."; return }
+    cmd /c "chkdsk $win /f /r"
+    Write-Host "[CHKDSK] Completed.`n"
+}
+
+function Run_SFC {
+    Write-Host "[SFC] Running offline SFC /scannow..." -ForegroundColor Cyan
+    $win = Get-WindowsDrive
+    if (-not $win) { Write-Warning "No Windows partition found."; return }
+    $windir = Join-Path $win "Windows"
+    cmd /c "sfc /scannow /offbootdir=$win\ /offwindir=$windir"
+    Write-Host "[SFC] Completed.`n"
+}
+
+function Try_EfiRebuild {
+    $win = Get-WindowsDrive
+    if (-not $win) { Write-Warning "No Windows partition found."; return }
+    $windir = Join-Path $win "Windows"
+
+    Write-Host "[EFI] Mounting EFI partition as S:..." -ForegroundColor Cyan
+    cmd /c "mountvol S: /S" 2>$null
+
+    if (-not (Test-Path "S:\")) {
+        Write-Warning "Failed to mount EFI partition. Skipping BCDBOOT."
+        return
+    }
+
+    Write-Host "[EFI] Running BCDBOOT from $windir..." -ForegroundColor Cyan
+    cmd /c "bcdboot $windir /s S: /f ALL"
+    Write-Host "[EFI] EFI boot files recreated."
+}
+
+function Run_Bootrec {
+    Write-Host "[BOOTREC] Starting boot repair..." -ForegroundColor Cyan
+
+    cmd /c "bootrec /fixmbr"
+    $fixboot = cmd /c "bootrec /fixboot" 2>&1
+    cmd /c "bootrec /scanos"
+    cmd /c "bootrec /rebuildbcd"
+
+    if ($fixboot -match 'Access is denied' -or $fixboot -match 'Toegang geweigerd') {
+        Write-Warning "[BOOTREC] Access denied on /fixboot. Attempting BCDBOOT fallback..."
+        Try-EfiRebuild
+    }
+
+    Write-Host "[BOOTREC] Boot repair finished.`n"
+}
+
+# Run back
+Write-Host "Starting full boot repair routine..." -ForegroundColor Green
+Run_Chkdsk
+Run_SFC
+Run_Bootrec
+Write-Host "`nAll steps completed. You may now reboot the system." -ForegroundColor Green


### PR DESCRIPTION
Add: Added a new .PS1 script that starts the boot recovery process. If users are stuck at the Windows Blue Screen (for as long as it is Blue) they can kick-off the script from the USB/CMD line.

It is written in .PS1 for convenience but the commands are originally from Batch.

Ingestion of the Powershell module needs to be added in W10 to work with this feature. Besides that, the function/script does work as intended but it needs to be given some love.

Note: It does not work from the W10, blue screen, CMD yet due lack of the powershell module.